### PR TITLE
fix: 换课菜单 ListWidget 不销毁导致的 setThemeColor 调用出错 #2470060288

### DIFF
--- a/extra_menu.py
+++ b/extra_menu.py
@@ -206,6 +206,14 @@ class ExtraMenu(FluentWindow):
 
         self.addSubInterface(self.interface, fIcon.INFO, '更多设置')
 
+    def closeEvent(self, e):
+        tmp_schedule_list = self.findChild(ListWidget, 'schedule_list')
+        if tmp_schedule_list:
+            tmp_schedule_list.clear()
+            tmp_schedule_list.setParent(None)
+        self.deleteLater()
+        return super().closeEvent(e)
+
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)


### PR DESCRIPTION
fuck 
 from https://api.github.com/repos/Class-Widgets/Class-Widgets/pulls/569